### PR TITLE
Scroll to an anchor on page load

### DIFF
--- a/src/components/VueAnchorRouterLink.vue
+++ b/src/components/VueAnchorRouterLink.vue
@@ -38,6 +38,11 @@ export default {
     $route: function(newRoute, oldRoute) {
       this.previousRoute = newRoute;
     }
+  },
+  mounted(){
+    if( this.$route.hash ){
+      this.$scrollTo(this.$route.hash, this.scrollOptions);
+    }
   }
 };
 </script>


### PR DESCRIPTION
When a page loads, the page does not scroll to anchors defined in the route. i.e `/#about`.

The ensures that the page scrolls to the anchor specified in the route on looad.